### PR TITLE
Taxonomy filter conflicts with main plugin

### DIFF
--- a/includes/class-ssp-speakers.php
+++ b/includes/class-ssp-speakers.php
@@ -197,7 +197,7 @@ class SSP_Speakers {
 		);
 
 		// Allow filtering of taxonomy arguments
-		$args = apply_filters( 'ssp_register_taxonomy_args', $args, $this->tax );
+		$args = apply_filters( 'ssp_speakers_register_taxonomy_args', $args, $this->tax );
 
 		// Get all selected podcast post types
 		$podcast_post_types = ssp_post_types( true );


### PR DESCRIPTION
It seems that the filter name is the same as the main SSP plugin, and it conflicts when using both plugins.

`ssp_register_taxonomy_args`

Meaning when using this filter it with take effect in both SSP and SSP Speakers.

My suggestion is simply to use the standard prefix set for each plugin, here it would be:

`ssp_speakers_register_taxonomy_args`

I guess it would do the trick, I've tried here and all went well.

Tip: Having in mind the simplicity proposal of the SSP plugins and also that not every user is a coder, It would be much simpler to users having this type of customization option (i.e. Labels) at the settings page on each plugin/add-on.